### PR TITLE
Add node 20 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x ]
+        node-version: [ 16.x, 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
PR adds node 20 to the CI test matrix. Node 20 was promoted to LTS a month ago, and so would be good to test against to confirm things work as expected. Node 16 is EOL, though I think a number of people (myself included) still use it that I'd want to leave it in for now.